### PR TITLE
KAFKA-7930: topic is not internal if explicitly listed in --input-topics or --intermediate-topics

### DIFF
--- a/core/src/main/scala/kafka/tools/StreamsResetter.java
+++ b/core/src/main/scala/kafka/tools/StreamsResetter.java
@@ -656,7 +656,8 @@ public class StreamsResetter {
 
 
     private boolean isInternalTopic(final String topicName) {
-        return topicName.startsWith(options.valueOf(applicationIdOption) + "-")
+        return !isInputTopic(topicName) && !isIntermediateTopic(topicName)
+            && topicName.startsWith(options.valueOf(applicationIdOption) + "-")
             && (topicName.endsWith("-changelog") || topicName.endsWith("-repartition"));
     }
 


### PR DESCRIPTION
Simplest fix: topic is not internal if explicitly listed in --input-topics or --intermediate-topics.